### PR TITLE
Proto spaceの修正

### DIFF
--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -5,6 +5,7 @@
       <div class="greeting">
         こんにちは、 
         <%= link_to "#{current_user.name}", user_path(current_user.id), class: :greeting__link %>
+        さん
       </div>
     <% end %>
     <%# // ログインしているときは上記を表示する %>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -49,7 +49,7 @@
           <% @comments.each do |comment| %>
             <li class="comments_list">
               <%= comment.content %>
-              <%= link_to "#{comment.user.name}", root_path, class: :comment_user %>
+              <%= link_to "#{comment.user.name}", user_path(comment.user_id), class: :comment_user %>
             </li>
           <% end %>
           <%# // 投稿に紐づくコメントを一覧する処理を記述する %>


### PR DESCRIPTION
・トップページの「こんにちは、〇〇」を「こんにちは、〇〇さん」へ変更しました
・コメント投稿者名がトップページへのリンクになっていたのを、コメント投稿者のユーザー詳細ページへのリンクに変更しました